### PR TITLE
feat(seo,styles): add mobile/Safari iOS dark fixes and meta tags

### DIFF
--- a/src/components/Seo/index.tsx
+++ b/src/components/Seo/index.tsx
@@ -84,6 +84,22 @@ const Seo: FC<Props> = ({ description, lang, title }) => {
           name: `linkedin:creator`,
           content: site.siteMetadata?.social?.linkedin || ``,
         },
+        {
+          name: `theme-color`,
+          content: `#0f0f23`,
+        },
+        {
+          name: `msapplication-TileColor`,
+          content: `#0f0f23`,
+        },
+        {
+          name: `apple-mobile-web-app-status-bar-style`,
+          content: `black-translucent`,
+        },
+        {
+          name: `viewport`,
+          content: `width=device-width, initial-scale=1, viewport-fit=cover`,
+        },
       ]}
     />
   );

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -112,6 +112,10 @@ html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   scroll-behavior: smooth;
+  
+  /* Force dark theme on Safari iOS */
+  color-scheme: dark;
+  background-color: var(--color-background) !important;
 }
 
 body {
@@ -123,6 +127,11 @@ body {
   margin: 0;
   padding: 0;
   position: relative;
+  
+  /* Force dark theme on Safari iOS */
+  -webkit-appearance: none;
+  color-scheme: dark;
+  background-color: var(--color-background) !important;
 }
 
 body::before {
@@ -500,6 +509,61 @@ a:focus {
 .grid-cols-1 { grid-template-columns: repeat(1, 1fr); }
 .grid-cols-2 { grid-template-columns: repeat(2, 1fr); }
 .grid-cols-3 { grid-template-columns: repeat(3, 1fr); }
+
+/* Safari iOS specific fixes */
+@supports (-webkit-touch-callout: none) {
+  html, body {
+    background-color: var(--color-background) !important;
+    color: var(--color-text) !important;
+  }
+  
+  /* Force glass morphism backgrounds to be visible */
+  .glass, .glass-card, .glass-nav {
+    background: rgba(15, 15, 35, 0.85) !important;
+    backdrop-filter: blur(20px) !important;
+    -webkit-backdrop-filter: blur(20px) !important;
+    border: 1px solid rgba(255, 255, 255, 0.2) !important;
+  }
+  
+  /* Ensure text is always visible */
+  p, h1, h2, h3, h4, h5, h6, span, a, li {
+    color: var(--color-text) !important;
+  }
+  
+  /* Force button text colors */
+  .btn, .btn-glass, .btn-primary {
+    color: var(--color-text) !important;
+  }
+  
+  .btn-primary {
+    color: white !important;
+    background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%) !important;
+  }
+  
+  /* Ensure gradient text is visible */
+  .text-gradient {
+    background: linear-gradient(135deg, #6366f1 0%, #f59e0b 100%) !important;
+    -webkit-background-clip: text !important;
+    -webkit-text-fill-color: transparent !important;
+    background-clip: text !important;
+  }
+  
+  /* Force main heading visibility */
+  .main-heading {
+    background: linear-gradient(135deg, #f1f5f9 0%, #818cf8 100%) !important;
+    -webkit-background-clip: text !important;
+    -webkit-text-fill-color: transparent !important;
+    background-clip: text !important;
+  }
+  
+  /* Add stronger background for body */
+  body::before {
+    background: 
+      radial-gradient(circle at 20% 80%, rgba(120, 119, 198, 0.4) 0%, transparent 50%),
+      radial-gradient(circle at 80% 20%, rgba(255, 119, 198, 0.2) 0%, transparent 50%),
+      radial-gradient(circle at 40% 40%, rgba(120, 219, 255, 0.15) 0%, transparent 50%) !important;
+  }
+}
 
 /* Mobile-first responsive improvements */
 @media (max-width: 360px) {


### PR DESCRIPTION
Add theme and viewport meta tags in Seo component to ensure the
browser and OS use the intended dark theme and responsive viewport
behavior (theme-color, msapplication-TileColor,
apple-mobile-web-app-status-bar-style, viewport).

Apply Safari iOS-specific CSS to force dark theme and improve
visibility. Set color-scheme and background-color on html/body and
body rules, include -webkit-appearance adjustments, and add a
@supports(-webkit-touch-callout: none) block with overrides that:
- enforce background and text colors
- restore glassmorphism backgrounds and backdrop filters
- ensure buttons and gradient text render legibly
- strengthen body::before background layers for better contrast

These changes address rendering issues on Safari iOS and mobile
browsers where the site previously showed incorrect theme colors,
invisible text, or broken translucent effects.